### PR TITLE
Fix bad method names

### DIFF
--- a/block_progress.php
+++ b/block_progress.php
@@ -70,7 +70,7 @@ class block_progress extends block_base {
      * @return bool
      */
     public function instance_allow_multiple() {
-        return !block_progress_on_site_page();
+        return !block_progress_on_my_page();
     }
 
     /**
@@ -79,7 +79,7 @@ class block_progress extends block_base {
      * @return bool
      */
     public function instance_allow_config() {
-        return !block_progress_on_site_page();
+        return !block_progress_on_my_page();
     }
 
     /**
@@ -119,7 +119,7 @@ class block_progress extends block_base {
         }
 
         // Draw the multi-bar content for the Dashboard and Front page.
-        if (block_progress_on_site_page()) {
+        if (block_progress_on_my_page()) {
             $courses = enrol_get_my_courses();
             $coursenametoshow = get_config('block_progress', 'coursenametoshow') ?: DEFAULT_COURSENAMETOSHOW;
             $sql = "SELECT bi.id,

--- a/edit_form.php
+++ b/edit_form.php
@@ -46,7 +46,7 @@ class block_progress_edit_form extends block_edit_form {
         raise_memory_limit(MEMORY_EXTRA);
 
         // The My home version is not configurable.
-        if (block_progress_on_site_page()) {
+        if (block_progress_on_my_page()) {
             return;
         }
 


### PR DESCRIPTION
This MR changes method names from `block_progress_on_site_page` to `block_progress_on_my_page` to avoid `Call to undefined function` error on edit mode.