### PR TITLE
block_progress: Check for null

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1147,6 +1147,8 @@ function block_progress_modules_in_use($course) {
  */
 function block_progress_event_information($config, $modules, $course, $userid = 0) {
     global $DB, $USER;
+   
+    if ($config === null) return 0;    
 
     $dbmanager = $DB->get_manager(); // Used to check if fields exist.
     $events = array();
@@ -1173,7 +1175,7 @@ function block_progress_event_information($config, $modules, $course, $userid = 
         // Check if this type of module is used in the course, gather instance info.
         $records = $DB->get_records($module, array('course' => $course), '', $fields);
         foreach ($records as $record) {
-
+            
             // Is the module being monitored?
             if (isset($config->{'monitor_'.$module.$record->id})) {
                 $numeventsconfigured++;


### PR DESCRIPTION
The block $this->config value can be null. 

When the following conditional is reached in lib.php a fatal error is thrown when $config is null because trying to get a property on null is not good:

progress_default_value($config->{'monitor_'.$module.$record->id}, 0) 